### PR TITLE
Send appName and appVersion for exception

### DIFF
--- a/ganalytics.cpp
+++ b/ganalytics.cpp
@@ -750,6 +750,9 @@ void GAnalytics::sendException(const QString &exceptionDescription,
                                const QVariantMap &customValues)
 {
     QUrlQuery query = d->buildStandardPostQuery("exception");
+    query.addQueryItem("an", d->appName);
+    query.addQueryItem("av", d->appVersion);
+
     query.addQueryItem("exd", exceptionDescription);
 
     if (exceptionFatal)


### PR DESCRIPTION
Otherwise, no exceptions are shown in the "Crashes and Exceptions" view with primary dimension "App Version"